### PR TITLE
fix(renovate): use default github label for dep upgrades

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -9,7 +9,7 @@
     ":assignAndReview(devtobi)",
     ":disableRateLimiting",
     ":enableVulnerabilityAlertsWithLabel(security)",
-    ":labels(renovate,dependency)",
+    ":labels(renovate,dependencies)",
     ":pinAllExceptPeerDependencies",
     ":prNotPending",
     ":rebaseStalePrs",


### PR DESCRIPTION
# Changes
Changed label `dependency` for renovate bot to `dependencies` to reuse default GitHub label