### PR TITLE
feat(ui): added dark mode feature to the app

### DIFF
--- a/packages/cv-wrapper/components.d.ts
+++ b/packages/cv-wrapper/components.d.ts
@@ -9,7 +9,9 @@ declare module 'vue' {
   export interface GlobalComponents {
     Avatar: typeof import('primevue/avatar')['default']
     Button: typeof import('primevue/button')['default']
+    CvAppearanceToggleButton: typeof import('./src/components/CvAppearanceToggleButton.vue')['default']
     CvFooter: typeof import('./src/components/CvFooter.vue')['default']
+    CvLanguageSelectDropdown: typeof import('./src/components/CvLanguageSelectDropdown.vue')['default']
     CvLanguageSelector: typeof import('./src/components/CvLanguageSelector.vue')['default']
     CvMenubar: typeof import('./src/components/CvMenubar.vue')['default']
     CvPdfDownloadButton: typeof import('./src/components/CvPdfDownloadButton.vue')['default']

--- a/packages/cv-wrapper/src/App.vue
+++ b/packages/cv-wrapper/src/App.vue
@@ -1,9 +1,7 @@
 <template>
   <div class="app-container flex flex-column min-h-screen">
     <the-menubar />
-    <main class="flex-1">
-      <span :class="operatingSystemIcon"></span>
-    </main>
+    <main class="flex-1"></main>
     <the-footer />
   </div>
 </template>
@@ -11,12 +9,11 @@
 <script lang="ts" setup>
   import TheFooter from '@/components/CvFooter.vue';
   import TheMenubar from '@/components/CvMenubar.vue';
+  import { useWatchAppearance } from '@/composables/useWatchAppearance';
   import { useWatchLanguage } from '@/composables/useWatchLanguage';
-  import { getOperatingSystemIcon } from '@/helpers/getOperatingSystemIcon';
-
-  const operatingSystemIcon = getOperatingSystemIcon();
 
   useWatchLanguage();
+  useWatchAppearance();
 </script>
 
 <style>

--- a/packages/cv-wrapper/src/components/CvAppearanceToggleButton.vue
+++ b/packages/cv-wrapper/src/components/CvAppearanceToggleButton.vue
@@ -1,0 +1,57 @@
+<template>
+  <Button
+    :icon="appearanceIcon"
+    :aria-label="ariaLabel"
+    v-tooltip.bottom="tooltipObject"
+    severity="contrast"
+    @click="toggleTheme"
+  />
+</template>
+
+<script setup lang="ts">
+  import { PrimeIcons } from 'primevue/api';
+  import { computed } from 'vue';
+  import { useI18n } from 'vue-i18n';
+
+  import { useSelectedAppearance } from '@/composables/useSelectedAppearance';
+  import { useThemedTooltip } from '@/composables/useThemedTooltip';
+  import { getOperatingSystemIcon } from '@/helpers/getOperatingSystemIcon';
+  import { Appearance } from '@/types/Appearance';
+
+  const { t } = useI18n();
+
+  const ariaLabel = computed(() =>
+    t(`CvAppearanceToggleButton.label`, {
+      appearance: tooltipLabel.value,
+    }),
+  );
+
+  const tooltipLabel = computed(() =>
+    t(`CvAppearanceToggleButton.appearances.${selectedAppearance.value}`),
+  );
+  const tooltipObject = useThemedTooltip(tooltipLabel, 'Bottom');
+
+  const themeOrder = [Appearance.LIGHT, Appearance.DARK, Appearance.SYSTEM];
+
+  const operatingSystemIcon = getOperatingSystemIcon();
+
+  const icons: Record<Appearance, string> = {
+    [Appearance.LIGHT]: PrimeIcons.SUN,
+    [Appearance.DARK]: PrimeIcons.MOON,
+    [Appearance.SYSTEM]: operatingSystemIcon,
+  };
+
+  const appearanceIcon = computed<string>(
+    () => icons[selectedAppearance.value as Appearance],
+  );
+
+  const { selectedAppearance } = useSelectedAppearance();
+
+  const toggleTheme = () => {
+    const currentAppearanceIndex = themeOrder.indexOf(
+      selectedAppearance.value as Appearance,
+    );
+    const newAppearanceIndex = (currentAppearanceIndex + 1) % themeOrder.length;
+    selectedAppearance.value = themeOrder[newAppearanceIndex];
+  };
+</script>

--- a/packages/cv-wrapper/src/components/CvFooter.vue
+++ b/packages/cv-wrapper/src/components/CvFooter.vue
@@ -1,6 +1,9 @@
 <template>
-  <footer class="text-center bg-transparent border-top-1 border-gray-200 p-1">
-    <p class="text-gray-500">
+  <footer
+    class="text-center bg-transparent border-top-1 p-1"
+    :class="borderClass"
+  >
+    <p :class="textClass">
       {{ staticStrings.CvFooter.copyright(currentYear) }}
     </p>
   </footer>
@@ -8,7 +11,11 @@
 
 <script setup lang="ts">
   import { useCurrentYear } from '@/composables/useCurrentYear';
+  import { useThemedClass } from '@/composables/useThemedClass';
   import { staticStrings } from '@/helpers/staticStrings';
+
+  const textClass = useThemedClass('text-gray-500', 'text-gray-100');
+  const borderClass = useThemedClass('border-gray-200', 'border-gray-700');
 
   const currentYear = useCurrentYear();
 </script>

--- a/packages/cv-wrapper/src/components/CvLanguageSelectDropdown.vue
+++ b/packages/cv-wrapper/src/components/CvLanguageSelectDropdown.vue
@@ -4,8 +4,8 @@
     :options="languages"
     option-label="name"
     option-value="code"
-    :placeholder="t('CvLanguageSelector.placeholder')"
-    :aria-label="t('CvLanguageSelector.placeholder')"
+    :placeholder="t('CvLanguageSelectDropdown.placeholder')"
+    :aria-label="t('CvLanguageSelectDropdown.placeholder')"
   >
     <template #value="slotProps">
       <div

--- a/packages/cv-wrapper/src/components/CvMenubar.vue
+++ b/packages/cv-wrapper/src/components/CvMenubar.vue
@@ -33,6 +33,7 @@
     </template>
     <template #end>
       <cv-pdf-download-button class="mr-3" />
+      <cv-appearance-toggle-button class="mr-3" />
       <cv-language-selector />
     </template>
   </menubar>
@@ -45,7 +46,7 @@
   import type { MenuItem } from 'primevue/menuitem';
 
   import profilePicture from '@/assets/images/profile_picture.png';
-  import CvLanguageSelector from '@/components/CvLanguageSelector.vue';
+  import CvLanguageSelector from '@/components/CvLanguageSelectDropdown.vue';
   import { authorName } from '@/config/constants';
   import menuLinks from '@/helpers/menuLinks';
 

--- a/packages/cv-wrapper/src/composables/useGetAppearance.ts
+++ b/packages/cv-wrapper/src/composables/useGetAppearance.ts
@@ -1,0 +1,22 @@
+import { usePreferredDark } from '@vueuse/core';
+import { computed } from 'vue';
+
+import { useSelectedAppearance } from '@/composables/useSelectedAppearance';
+import { Appearance } from '@/types/Appearance';
+
+export const useGetAppearance = () => {
+  const prefersDark = usePreferredDark();
+  const { selectedAppearance } = useSelectedAppearance();
+
+  const appearance = computed(() =>
+    selectedAppearance.value === Appearance.SYSTEM
+      ? prefersDark.value
+        ? Appearance.DARK
+        : Appearance.LIGHT
+      : selectedAppearance.value,
+  );
+
+  return {
+    appearance,
+  };
+};

--- a/packages/cv-wrapper/src/composables/useSelectedAppearance.ts
+++ b/packages/cv-wrapper/src/composables/useSelectedAppearance.ts
@@ -1,0 +1,16 @@
+import { RemovableRef, useStorage } from '@vueuse/core';
+
+import { Appearance } from '@/types/Appearance';
+
+export const useSelectedAppearance = () => {
+  const STORAGE_KEY = 'appearance';
+
+  const selectedAppearance: RemovableRef<string> = useStorage(
+    STORAGE_KEY,
+    Appearance.SYSTEM,
+  );
+
+  return {
+    selectedAppearance,
+  };
+};

--- a/packages/cv-wrapper/src/composables/useThemedClass.ts
+++ b/packages/cv-wrapper/src/composables/useThemedClass.ts
@@ -1,0 +1,12 @@
+import { computed } from 'vue';
+
+import { useGetAppearance } from '@/composables/useGetAppearance';
+import { Appearance } from '@/types/Appearance';
+
+export const useThemedClass = (lightClass: string, darkClass: string) => {
+  const { appearance } = useGetAppearance();
+
+  return computed(() =>
+    appearance.value === Appearance.DARK ? darkClass : lightClass,
+  );
+};

--- a/packages/cv-wrapper/src/composables/useThemedTooltip.ts
+++ b/packages/cv-wrapper/src/composables/useThemedTooltip.ts
@@ -1,0 +1,30 @@
+import { computed, Ref } from 'vue';
+
+import { useThemedClass } from '@/composables/useThemedClass';
+
+export const useThemedTooltip = (
+  text: Ref<string>,
+  direction: 'Left' | 'Right' | 'Bottom' | 'Top' = 'Bottom',
+) => {
+  const textClass = useThemedClass(
+    'text-gray-100 bg-black',
+    'text-gray-700 bg-white',
+  );
+
+  const arrowColor = 'var(--text-color)';
+  const borderAttribute = `border${direction}Color`;
+
+  return computed(() => {
+    return {
+      value: text.value,
+      pt: {
+        arrow: {
+          style: {
+            [borderAttribute]: arrowColor,
+          },
+        },
+        text: textClass.value,
+      },
+    };
+  });
+};

--- a/packages/cv-wrapper/src/composables/useWatchAppearance.ts
+++ b/packages/cv-wrapper/src/composables/useWatchAppearance.ts
@@ -1,0 +1,26 @@
+import { usePrimeVue } from 'primevue/config';
+import { watch } from 'vue';
+
+import { useGetAppearance } from '@/composables/useGetAppearance';
+import { darkTheme, lightTheme, themeLinkHtml } from '@/config/constants';
+import { Appearance } from '@/types/Appearance';
+
+export const useWatchAppearance = () => {
+  const PrimeVue = usePrimeVue();
+  const { appearance } = useGetAppearance();
+
+  const setPrimeVueAppearance = (appearance: string) => {
+    const isLightTheme = appearance === Appearance.LIGHT;
+    const currentTheme = isLightTheme ? darkTheme : lightTheme;
+    const newTheme = isLightTheme ? lightTheme : darkTheme;
+    PrimeVue.changeTheme(currentTheme, newTheme, themeLinkHtml);
+  };
+
+  watch(
+    [appearance],
+    () => {
+      setPrimeVueAppearance(appearance.value);
+    },
+    { immediate: true },
+  );
+};

--- a/packages/cv-wrapper/src/config/constants.ts
+++ b/packages/cv-wrapper/src/config/constants.ts
@@ -6,6 +6,9 @@ const linkedinName = 'tobias-stadler';
 const websiteUrl = 'https://devtobi.de';
 const defaultLocale: Extract<SupportedLocale, 'en'> = 'en';
 const pdfFilename = 'cv.pdf';
+const lightTheme = 'aura-light-green';
+const darkTheme = 'aura-dark-green';
+const themeLinkHtml = 'theme-link';
 
 export {
   authorName,
@@ -14,4 +17,7 @@ export {
   websiteUrl,
   defaultLocale,
   pdfFilename,
+  lightTheme,
+  darkTheme,
+  themeLinkHtml,
 };

--- a/packages/cv-wrapper/src/locales/de.json
+++ b/packages/cv-wrapper/src/locales/de.json
@@ -9,10 +9,18 @@
       }
     }
   },
-  "CvLanguageSelector": {
+  "CvLanguageSelectDropdown": {
     "placeholder": "Sprache"
   },
   "CvPdfDownloadButton": {
     "label": "Als PDF herunterladen"
+  },
+  "CvAppearanceToggleButton": {
+    "label": "Erscheinungsbild: {appearance}",
+    "appearances": {
+      "light": "Hell",
+      "dark": "Dunkel",
+      "system": "System"
+    }
   }
 }

--- a/packages/cv-wrapper/src/locales/en.json
+++ b/packages/cv-wrapper/src/locales/en.json
@@ -9,10 +9,18 @@
       }
     }
   },
-  "CvLanguageSelector": {
+  "CvLanguageSelectDropdown": {
     "placeholder": "Language"
   },
   "CvPdfDownloadButton": {
     "label": "Download as PDF"
+  },
+  "CvAppearanceToggleButton": {
+    "label": "Appearance: {appearance}",
+    "appearances": {
+      "light": "Light",
+      "dark": "Dark",
+      "system": "System"
+    }
   }
 }

--- a/packages/cv-wrapper/src/main.ts
+++ b/packages/cv-wrapper/src/main.ts
@@ -1,3 +1,4 @@
+import Tooltip from 'primevue/tooltip';
 import { createApp } from 'vue';
 
 import { registerPlugins } from '@/plugins';
@@ -7,4 +8,5 @@ const app = createApp(App);
 
 registerPlugins(app);
 
+app.directive('tooltip', Tooltip);
 app.mount('#app');

--- a/packages/cv-wrapper/src/types/Appearance.ts
+++ b/packages/cv-wrapper/src/types/Appearance.ts
@@ -1,0 +1,5 @@
+export enum Appearance {
+  LIGHT = 'light',
+  DARK = 'dark',
+  SYSTEM = 'system',
+}


### PR DESCRIPTION
# Changes
- Added Dark Mode Feature
- Added AppearanceToggle component using custom OS icon for "system" setting
- Added composable to swap appearance depending on mode in non PrimeVue custom components
- Added composable to get current appearance (dark / light) because PrimeVue has no read access to it
- Added composable to access and save appearance in localStorage
- Added composable to build custom tooltips depending on current appearance
- Added more localizations for new components
- Added utility types