### PR TITLE
68 add metadata for dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,23 +1,29 @@
 {
-  "name": "cv",
-  "version": "1.0.0",
-  "devDependencies": {
-    "@ianvs/prettier-plugin-sort-imports": "4.2.1",
-    "concurrently": "8.2.2",
-    "globals": "15.5.0",
-    "ncp": "2.0.0",
-    "prettier": "3.3.2"
-  },
-  "description": "My CV application as a monorepo built using Vue.js and resumed",
-  "private": true,
-  "scripts": {
-    "build": "bun --filter '*' build && bun post-build",
-    "post-build": "mkdir -p dist && concurrently --kill-others-on-fail -n copy-content,copy-wrapper 'ncp packages/cv-content/dist dist/' 'ncp packages/cv-wrapper/dist dist/'",
-    "setup": "bun --filter cv-content setup",
-    "format": "bun --filter cv-content format",
-    "validate": "bun --filter cv-content validate",
-    "lint": "bun --filter '*' lint",
-    "fix": "bun --filter '*' fix"
-  },
-  "workspaces": ["packages/*"]
+	"name": "cv",
+	"version": "1.0.0",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/devtobi/cv.git"
+	},
+	"devDependencies": {
+		"@ianvs/prettier-plugin-sort-imports": "4.2.1",
+		"concurrently": "8.2.2",
+		"globals": "15.5.0",
+		"ncp": "2.0.0",
+		"prettier": "3.3.2"
+	},
+	"description": "My CV application as a monorepo built using Vue.js and resumed",
+	"private": true,
+	"scripts": {
+		"build": "bun --filter '*' build && bun post-build",
+		"post-build": "mkdir -p dist && concurrently --kill-others-on-fail -n copy-content,copy-wrapper 'ncp packages/cv-content/dist dist/' 'ncp packages/cv-wrapper/dist dist/'",
+		"setup": "bun --filter cv-content setup",
+		"format": "bun --filter cv-content format",
+		"validate": "bun --filter cv-content validate",
+		"lint": "bun --filter '*' lint",
+		"fix": "bun --filter '*' fix"
+	},
+	"workspaces": [
+		"packages/*"
+	]
 }

--- a/package.json
+++ b/package.json
@@ -1,29 +1,29 @@
 {
-	"name": "cv",
-	"version": "1.0.0",
-	"repository": {
-		"type": "git",
-		"url": "https://github.com/devtobi/cv.git"
-	},
-	"devDependencies": {
-		"@ianvs/prettier-plugin-sort-imports": "4.2.1",
-		"concurrently": "8.2.2",
-		"globals": "15.5.0",
-		"ncp": "2.0.0",
-		"prettier": "3.3.2"
-	},
-	"description": "My CV application as a monorepo built using Vue.js and resumed",
-	"private": true,
-	"scripts": {
-		"build": "bun --filter '*' build && bun post-build",
-		"post-build": "mkdir -p dist && concurrently --kill-others-on-fail -n copy-content,copy-wrapper 'ncp packages/cv-content/dist dist/' 'ncp packages/cv-wrapper/dist dist/'",
-		"setup": "bun --filter cv-content setup",
-		"format": "bun --filter cv-content format",
-		"validate": "bun --filter cv-content validate",
-		"lint": "bun --filter '*' lint",
-		"fix": "bun --filter '*' fix"
-	},
-	"workspaces": [
-		"packages/*"
-	]
+  "name": "cv",
+  "version": "1.0.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/devtobi/cv.git"
+  },
+  "devDependencies": {
+    "@ianvs/prettier-plugin-sort-imports": "4.2.1",
+    "concurrently": "8.2.2",
+    "globals": "15.5.0",
+    "ncp": "2.0.0",
+    "prettier": "3.3.2"
+  },
+  "description": "My CV application as a monorepo built using Vue.js and resumed",
+  "private": true,
+  "scripts": {
+    "build": "bun --filter '*' build && bun post-build",
+    "post-build": "mkdir -p dist && concurrently --kill-others-on-fail -n copy-content,copy-wrapper 'ncp packages/cv-content/dist dist/' 'ncp packages/cv-wrapper/dist dist/'",
+    "setup": "bun --filter cv-content setup",
+    "format": "bun --filter cv-content format",
+    "validate": "bun --filter cv-content validate",
+    "lint": "bun --filter '*' lint",
+    "fix": "bun --filter '*' fix"
+  },
+  "workspaces": [
+    "packages/*"
+  ]
 }

--- a/packages/cv-wrapper/components.d.ts
+++ b/packages/cv-wrapper/components.d.ts
@@ -11,11 +11,15 @@ declare module 'vue' {
     Button: typeof import('primevue/button')['default']
     CvAppearanceToggleButton: typeof import('./src/components/CvAppearanceToggleButton.vue')['default']
     CvFooter: typeof import('./src/components/CvFooter.vue')['default']
+    CvInformationDialog: typeof import('@/components/CvInformationDialogButton.vue')['default']
+    CvInformationDialogButton: typeof import('./src/components/CvInformationDialogButton.vue')['default']
     CvLanguageSelectDropdown: typeof import('./src/components/CvLanguageSelectDropdown.vue')['default']
     CvLanguageSelector: typeof import('./src/components/CvLanguageSelector.vue')['default']
     CvMenubar: typeof import('./src/components/CvMenubar.vue')['default']
     CvPdfDownloadButton: typeof import('./src/components/CvPdfDownloadButton.vue')['default']
+    Dialog: typeof import('primevue/dialog')['default']
     Dropdown: typeof import('primevue/dropdown')['default']
+    InputText: typeof import('primevue/inputtext')['default']
     Menubar: typeof import('primevue/menubar')['default']
   }
 }

--- a/packages/cv-wrapper/components.d.ts
+++ b/packages/cv-wrapper/components.d.ts
@@ -9,7 +9,9 @@ declare module 'vue' {
   export interface GlobalComponents {
     Avatar: typeof import('primevue/avatar')['default']
     Button: typeof import('primevue/button')['default']
+    Column: typeof import('primevue/column')['default']
     CvAppearanceToggleButton: typeof import('./src/components/CvAppearanceToggleButton.vue')['default']
+    CvDependencyDataTable: typeof import('./src/components/CvDependencyDataTable.vue')['default']
     CvFooter: typeof import('./src/components/CvFooter.vue')['default']
     CvInformationDialog: typeof import('@/components/CvInformationDialogButton.vue')['default']
     CvInformationDialogButton: typeof import('./src/components/CvInformationDialogButton.vue')['default']
@@ -17,9 +19,11 @@ declare module 'vue' {
     CvLanguageSelector: typeof import('./src/components/CvLanguageSelector.vue')['default']
     CvMenubar: typeof import('./src/components/CvMenubar.vue')['default']
     CvPdfDownloadButton: typeof import('./src/components/CvPdfDownloadButton.vue')['default']
+    DataTable: typeof import('primevue/datatable')['default']
     Dialog: typeof import('primevue/dialog')['default']
     Dropdown: typeof import('primevue/dropdown')['default']
     InputText: typeof import('primevue/inputtext')['default']
     Menubar: typeof import('primevue/menubar')['default']
+    Tag: typeof import('primevue/tag')['default']
   }
 }

--- a/packages/cv-wrapper/env.d.ts
+++ b/packages/cv-wrapper/env.d.ts
@@ -3,8 +3,10 @@
 
 interface ImportMetaEnv {
   readonly PACKAGE_REPOSITORY_URL: string;
-  readonly PACKAGE_DEPENDENCIES: Record<string, string>;
   readonly PACKAGE_DEV_DEPENDENCIES: Record<string, string>;
+  readonly CV_CONTENT_PACKAGE_DEV_DEPENDENCIES: Record<string, string>;
+  readonly CV_WRAPPER_PACKAGE_DEV_DEPENDENCIES: Record<string, string>;
+  readonly CV_WRAPPER_PACKAGE_DEPENDENCIES: Record<string, string>;
 }
 
 interface ImportMeta {

--- a/packages/cv-wrapper/env.d.ts
+++ b/packages/cv-wrapper/env.d.ts
@@ -1,2 +1,12 @@
 /// <reference types="vite/client" />
 /// <reference types="user-agent-data-types" />
+
+interface ImportMetaEnv {
+  readonly PACKAGE_REPOSITORY_URL: string;
+  readonly PACKAGE_DEPENDENCIES: Record<string, string>;
+  readonly PACKAGE_DEV_DEPENDENCIES: Record<string, string>;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}

--- a/packages/cv-wrapper/package.json
+++ b/packages/cv-wrapper/package.json
@@ -4,6 +4,10 @@
   "private": true,
   "type": "module",
   "description": "My Vue based wrapper application for serving the CV content dynamically and providing additional features",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/devtobi/cv.git"
+  },
   "scripts": {
     "dev": "vite",
     "build": "bun run pre-build && vue-tsc --build --force && vite build",

--- a/packages/cv-wrapper/package.json
+++ b/packages/cv-wrapper/package.json
@@ -4,10 +4,6 @@
   "private": true,
   "type": "module",
   "description": "My Vue based wrapper application for serving the CV content dynamically and providing additional features",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/devtobi/cv.git"
-  },
   "scripts": {
     "dev": "vite",
     "build": "bun run pre-build && vue-tsc --build --force && vite build",

--- a/packages/cv-wrapper/src/components/CvDependencyDataTable.vue
+++ b/packages/cv-wrapper/src/components/CvDependencyDataTable.vue
@@ -1,0 +1,135 @@
+<template>
+  <DataTable
+    v-model:selection="selectedRow"
+    :value="dependencies"
+    size="small"
+    @row-click="openNpmPage"
+    table-style="min-width: 50%"
+    sort-field="type"
+    :sort-order="-1"
+    scrollable
+    scroll-height="flex"
+    selection-mode="single"
+  >
+    <Column
+      field="name"
+      :header="t('CvDependencyDataTable.columnNames.name')"
+    />
+    <Column
+      field="version"
+      :header="t('CvDependencyDataTable.columnNames.version')"
+    />
+    <Column
+      field="type"
+      :header="t('CvDependencyDataTable.columnNames.type')"
+    >
+      <template #body="slotProps">
+        <Tag
+          :value="
+            t(
+              `CvDependencyDataTable.dependencyTypeNames.${slotProps.data.type}`,
+            )
+          "
+          :severity="getTypeTagSeverity(slotProps.data.type)"
+          class="flex flex-row"
+        />
+      </template>
+    </Column>
+    <Column
+      field="component"
+      :header="t('CvDependencyDataTable.columnNames.component')"
+    >
+      <template #body="slotProps">
+        <Tag
+          :value="
+            t(
+              `CvDependencyDataTable.dependencyComponentNames.${slotProps.data.component}`,
+            )
+          "
+          :severity="getComponentTagSeverity(slotProps.data.component)"
+          class="flex flex-row"
+        />
+      </template>
+    </Column>
+  </DataTable>
+</template>
+
+<script setup lang="ts">
+  import { ref } from 'vue';
+  import { useI18n } from 'vue-i18n';
+
+  import { npmPackageUrl } from '@/config/constants';
+  import { generatePackageDependencyList } from '@/helpers/generatePackageDependencyList';
+  import {
+    PackageDependencyComponentType,
+    PackageDependencyType,
+  } from '@/types/PackageDependency';
+
+  const { t } = useI18n();
+
+  const devDependenciesData = import.meta.env.PACKAGE_DEV_DEPENDENCIES;
+  const contentDevDependenciesData = import.meta.env
+    .CV_CONTENT_PACKAGE_DEV_DEPENDENCIES;
+  const wrapperDevDependenciesData = import.meta.env
+    .CV_WRAPPER_PACKAGE_DEV_DEPENDENCIES;
+
+  const wrapperDependenciesData = import.meta.env
+    .CV_WRAPPER_PACKAGE_DEPENDENCIES;
+
+  const devDependencies = generatePackageDependencyList(
+    devDependenciesData,
+    PackageDependencyType.DEVELOPMENT,
+    PackageDependencyComponentType.ALL,
+  );
+  const contentDevDependencies = generatePackageDependencyList(
+    contentDevDependenciesData,
+    PackageDependencyType.DEVELOPMENT,
+    PackageDependencyComponentType.CV_CONTENT,
+  );
+  const wrapperDevDependencies = generatePackageDependencyList(
+    wrapperDevDependenciesData,
+    PackageDependencyType.DEVELOPMENT,
+    PackageDependencyComponentType.CV_WRAPPER,
+  );
+
+  const wrapperDependencies = generatePackageDependencyList(
+    wrapperDependenciesData,
+    PackageDependencyType.PRODUCTION,
+    PackageDependencyComponentType.CV_WRAPPER,
+  );
+
+  const dependencies = [
+    ...devDependencies,
+    ...contentDevDependencies,
+    ...wrapperDevDependencies,
+    ...wrapperDependencies,
+  ];
+
+  const selectedRow = ref();
+
+  const getTypeTagSeverity = (type: PackageDependencyType) => {
+    switch (type) {
+      case PackageDependencyType.DEVELOPMENT:
+        return 'warning';
+      case PackageDependencyType.PRODUCTION:
+        return 'info';
+    }
+  };
+
+  const getComponentTagSeverity = (type: PackageDependencyComponentType) => {
+    switch (type) {
+      case PackageDependencyComponentType.ALL:
+        return 'info';
+      case PackageDependencyComponentType.CV_CONTENT:
+        return 'warning';
+      case PackageDependencyComponentType.CV_WRAPPER:
+        return 'error';
+    }
+  };
+
+  const openNpmPage = (event: any) => {
+    const packageName = event.data.name;
+    const url = `${npmPackageUrl}${packageName}`;
+    window.open(url, '_blank')!.focus();
+  };
+</script>

--- a/packages/cv-wrapper/src/components/CvInformationDialogButton.vue
+++ b/packages/cv-wrapper/src/components/CvInformationDialogButton.vue
@@ -1,0 +1,33 @@
+<template>
+  <Button
+    :icon="PrimeIcons.INFO_CIRCLE"
+    severity="secondary"
+    outlined
+    @click="showDialog = true"
+    :aria-label="t('CvInformationDialogButton.label')"
+    :aria-controls="showDialog ? dialogId : undefined"
+    :aria-expanded="showDialog"
+  />
+
+  <Dialog
+    :id="dialogId"
+    v-model:visible="showDialog"
+    modal
+    :header="t('CvInformationDialogButton.appInfo')"
+    :style="{ width: '25rem' }"
+  >
+
+  </Dialog>
+</template>
+
+<script setup lang="ts">
+  import { PrimeIcons } from 'primevue/api';
+  import { ref } from 'vue';
+  import { useI18n } from 'vue-i18n';
+
+  const showDialog = ref(false);
+
+  const dialogId = 'appInfoDialog';
+
+  const { t } = useI18n();
+</script>

--- a/packages/cv-wrapper/src/components/CvInformationDialogButton.vue
+++ b/packages/cv-wrapper/src/components/CvInformationDialogButton.vue
@@ -14,8 +14,37 @@
     v-model:visible="showDialog"
     modal
     :header="t('CvInformationDialogButton.appInfo')"
-    :style="{ width: '25rem' }"
+    maximizable
+    :contentStyle="{ height: '30rem' }"
+    :style="{ width: '50rem' }"
   >
+    <template #header>
+      <div class="flex align-items-center">
+        <span class="font-bold white-space-nowrap ml-2 mr-5">{{
+          t('CvInformationDialogButton.appInfo')
+        }}</span>
+        <Button
+          :label="t('CvInformationDialogButton.githubLink')"
+          :icon="PrimeIcons.GITHUB"
+          severity="contrast"
+          @click="openRepository"
+        />
+      </div>
+    </template>
+    <CvDependencyDataTable />
+    <template #footer>
+      <div class="w-full flex flex-row justify-content-center">
+        <p>
+          {{ t('CvInformationDialogButton.footerText1') }}
+          <span
+            :class="PrimeIcons.HEART"
+            style="color: var(--red-500)"
+            :aria-label="t('CvInformationDialogButton.footerLoveAria')"
+          />
+          {{ t('CvInformationDialogButton.footerText2') }}
+        </p>
+      </div>
+    </template>
   </Dialog>
 </template>
 
@@ -26,7 +55,13 @@
 
   const showDialog = ref(false);
 
+  const repoUrl = import.meta.env.PACKAGE_REPOSITORY_URL;
+
   const dialogId = 'appInfoDialog';
+
+  const openRepository = () => {
+    window.open(repoUrl, '_blank')!.focus();
+  };
 
   const { t } = useI18n();
 </script>

--- a/packages/cv-wrapper/src/components/CvInformationDialogButton.vue
+++ b/packages/cv-wrapper/src/components/CvInformationDialogButton.vue
@@ -16,7 +16,6 @@
     :header="t('CvInformationDialogButton.appInfo')"
     :style="{ width: '25rem' }"
   >
-
   </Dialog>
 </template>
 

--- a/packages/cv-wrapper/src/components/CvMenubar.vue
+++ b/packages/cv-wrapper/src/components/CvMenubar.vue
@@ -33,8 +33,9 @@
     </template>
     <template #end>
       <cv-pdf-download-button class="mr-3" />
+      <cv-language-selector class="mr-3" />
       <cv-appearance-toggle-button class="mr-3" />
-      <cv-language-selector />
+      <cv-information-dialog-button />
     </template>
   </menubar>
 </template>
@@ -46,6 +47,7 @@
   import type { MenuItem } from 'primevue/menuitem';
 
   import profilePicture from '@/assets/images/profile_picture.png';
+  import CvInformationDialogButton from '@/components/CvInformationDialogButton.vue';
   import CvLanguageSelector from '@/components/CvLanguageSelectDropdown.vue';
   import { authorName } from '@/config/constants';
   import menuLinks from '@/helpers/menuLinks';

--- a/packages/cv-wrapper/src/composables/useWatchLanguage.ts
+++ b/packages/cv-wrapper/src/composables/useWatchLanguage.ts
@@ -1,10 +1,10 @@
+import { usePrimeVue } from 'primevue/config';
 import { watch } from 'vue';
+import { useI18n } from 'vue-i18n';
 
 import { useSelectedLanguage } from '@/composables/useSelectedLanguage';
 import { loadLanguage } from '@/plugins/i18n';
 import { SupportedLocale } from '@/types/SupportedLocale';
-import { useI18n } from 'vue-i18n';
-import { usePrimeVue } from 'primevue/config';
 
 export const useWatchLanguage = () => {
   const { selectedLanguage } = useSelectedLanguage();
@@ -15,12 +15,12 @@ export const useWatchLanguage = () => {
     selectedLanguage,
     async (code: SupportedLocale) => {
       await loadLanguage(code);
-	  updatePrimeVueLocalizations()
+      updatePrimeVueLocalizations();
     },
     { immediate: true },
   );
 
   const updatePrimeVueLocalizations = () => {
-	PrimeVue.config.locale!.aria!.close = t('PrimeVue.aria');
-  }
+    PrimeVue.config.locale!.aria!.close = t('PrimeVue.aria');
+  };
 };

--- a/packages/cv-wrapper/src/composables/useWatchLanguage.ts
+++ b/packages/cv-wrapper/src/composables/useWatchLanguage.ts
@@ -3,15 +3,24 @@ import { watch } from 'vue';
 import { useSelectedLanguage } from '@/composables/useSelectedLanguage';
 import { loadLanguage } from '@/plugins/i18n';
 import { SupportedLocale } from '@/types/SupportedLocale';
+import { useI18n } from 'vue-i18n';
+import { usePrimeVue } from 'primevue/config';
 
 export const useWatchLanguage = () => {
   const { selectedLanguage } = useSelectedLanguage();
+  const { t } = useI18n();
+  const PrimeVue = usePrimeVue();
 
   watch(
     selectedLanguage,
     async (code: SupportedLocale) => {
       await loadLanguage(code);
+	  updatePrimeVueLocalizations()
     },
     { immediate: true },
   );
+
+  const updatePrimeVueLocalizations = () => {
+	PrimeVue.config.locale!.aria!.close = t('PrimeVue.aria');
+  }
 };

--- a/packages/cv-wrapper/src/composables/useWatchLanguage.ts
+++ b/packages/cv-wrapper/src/composables/useWatchLanguage.ts
@@ -21,6 +21,6 @@ export const useWatchLanguage = () => {
   );
 
   const updatePrimeVueLocalizations = () => {
-    PrimeVue.config.locale!.aria!.close = t('PrimeVue.aria');
+    PrimeVue.config.locale!.aria!.close = t('PrimeVue.aria.close');
   };
 };

--- a/packages/cv-wrapper/src/config/constants.ts
+++ b/packages/cv-wrapper/src/config/constants.ts
@@ -9,6 +9,7 @@ const pdfFilename = 'cv.pdf';
 const lightTheme = 'aura-light-green';
 const darkTheme = 'aura-dark-green';
 const themeLinkHtml = 'theme-link';
+const npmPackageUrl = 'https://www.npmjs.com/package/';
 
 export {
   authorName,
@@ -20,4 +21,5 @@ export {
   lightTheme,
   darkTheme,
   themeLinkHtml,
+  npmPackageUrl,
 };

--- a/packages/cv-wrapper/src/helpers/generatePackageDependencyList.ts
+++ b/packages/cv-wrapper/src/helpers/generatePackageDependencyList.ts
@@ -1,0 +1,21 @@
+import {
+  PackageDependency,
+  PackageDependencyComponentType,
+  PackageDependencyType,
+} from '@/types/PackageDependency';
+
+export const generatePackageDependencyList = (
+  dependencies: Record<string, string>,
+  type: PackageDependencyType,
+  component: PackageDependencyComponentType,
+) => {
+  return Object.entries(dependencies).map(
+    ([name, version]) =>
+      ({
+        name,
+        version,
+        type,
+        component,
+      }) as PackageDependency,
+  );
+};

--- a/packages/cv-wrapper/src/locales/de.json
+++ b/packages/cv-wrapper/src/locales/de.json
@@ -1,4 +1,9 @@
 {
+  "PrimeVue": {
+    "aria": {
+		"close": "Schließen"
+	}
+  },
   "CvMenubar": {
     "profilePictureAltText": "Profilbild von {authorName}",
     "newFeaturesSoon": "Neue Funktionen werden bald hinzugefügt!",
@@ -22,5 +27,9 @@
       "dark": "Dunkel",
       "system": "System"
     }
+  },
+  "CvInformationDialogButton": {
+    "appInfo": "App-Informationen",
+    "label": "@:CvInformationDialogButton.appInfo anzeigen"
   }
 }

--- a/packages/cv-wrapper/src/locales/de.json
+++ b/packages/cv-wrapper/src/locales/de.json
@@ -30,6 +30,27 @@
   },
   "CvInformationDialogButton": {
     "appInfo": "App-Informationen",
-    "label": "@:CvInformationDialogButton.appInfo anzeigen"
+    "label": "@:CvInformationDialogButton.appInfo anzeigen",
+    "githubLink": "Auf GitHub ansehen",
+    "footerText1": "Entwickelt mit",
+    "footerText2": "und Vue.js",
+    "footerLoveAria": "Liebe"
+  },
+  "CvDependencyDataTable": {
+    "columnNames": {
+      "name": "Paketname",
+      "version": "Versionsnummer",
+      "type": "Typ",
+      "component": "Softwarekomponente"
+    },
+    "dependencyTypeNames": {
+      "prod": "Produktion",
+      "dev": "Entwicklung"
+    },
+    "dependencyComponentNames": {
+      "all": "Alle",
+      "cv-content": "CV-Inhalt",
+      "cv-wrapper": "Vue SPA"
+    }
   }
 }

--- a/packages/cv-wrapper/src/locales/de.json
+++ b/packages/cv-wrapper/src/locales/de.json
@@ -1,8 +1,8 @@
 {
   "PrimeVue": {
     "aria": {
-		"close": "Schließen"
-	}
+      "close": "Schließen"
+    }
   },
   "CvMenubar": {
     "profilePictureAltText": "Profilbild von {authorName}",

--- a/packages/cv-wrapper/src/locales/en.json
+++ b/packages/cv-wrapper/src/locales/en.json
@@ -1,9 +1,9 @@
 {
-	"PrimeVue": {
-		"aria": {
-			"close": "Close"
-		}
-	},
+  "PrimeVue": {
+    "aria": {
+      "close": "Close"
+    }
+  },
   "CvMenubar": {
     "profilePictureAltText": "Profile picture of {authorName}",
     "newFeaturesSoon": "New features will be added soon!",

--- a/packages/cv-wrapper/src/locales/en.json
+++ b/packages/cv-wrapper/src/locales/en.json
@@ -44,8 +44,8 @@
       "component": "Software component"
     },
     "dependencyTypeNames": {
-      "prod": "Produktion",
-      "dev": "Entwicklung"
+      "prod": "Production",
+      "dev": "Development"
     },
     "dependencyComponentNames": {
       "all": "All",

--- a/packages/cv-wrapper/src/locales/en.json
+++ b/packages/cv-wrapper/src/locales/en.json
@@ -30,6 +30,29 @@
   },
   "CvInformationDialogButton": {
     "appInfo": "App information",
-    "label": "Show @:CvInformationDialogButton.appInfo"
+    "label": "Show @:CvInformationDialogButton.appInfo",
+    "githubLink": "View on GitHub",
+    "footerText1": "Developed with",
+    "footerText2": "using Vue.js",
+    "footerLoveAria": "love"
+  },
+  "CvDependencyDataTable": {
+    "columnNames": {
+      "name": "Package name",
+      "version": "Version number",
+      "type": "Type",
+      "component": "Software component"
+    },
+    "dependencyTypeNames": {
+      "prod": "Produktion",
+      "dev": "Entwicklung"
+    },
+    "dependencyComponentNames": {
+      "all": "All",
+      "cv-content": "CV content",
+      "cv-wrapper": "Vue SPA"
+    },
+    "footerText1": "Made with",
+    "footerText2": "and Vue.js"
   }
 }

--- a/packages/cv-wrapper/src/locales/en.json
+++ b/packages/cv-wrapper/src/locales/en.json
@@ -1,4 +1,9 @@
 {
+	"PrimeVue": {
+		"aria": {
+			"close": "Close"
+		}
+	},
   "CvMenubar": {
     "profilePictureAltText": "Profile picture of {authorName}",
     "newFeaturesSoon": "New features will be added soon!",
@@ -22,5 +27,9 @@
       "dark": "Dark",
       "system": "System"
     }
+  },
+  "CvInformationDialogButton": {
+    "appInfo": "App information",
+    "label": "Show @:CvInformationDialogButton.appInfo"
   }
 }

--- a/packages/cv-wrapper/src/types/PackageDependency.ts
+++ b/packages/cv-wrapper/src/types/PackageDependency.ts
@@ -1,0 +1,4 @@
+export type PackageDependency = {
+  name: string;
+  version: string;
+};

--- a/packages/cv-wrapper/src/types/PackageDependency.ts
+++ b/packages/cv-wrapper/src/types/PackageDependency.ts
@@ -1,4 +1,17 @@
+export enum PackageDependencyType {
+  PRODUCTION = 'prod',
+  DEVELOPMENT = 'dev',
+}
+
+export enum PackageDependencyComponentType {
+  CV_CONTENT = 'cv-content',
+  CV_WRAPPER = 'cv-wrapper',
+  ALL = 'all',
+}
+
 export type PackageDependency = {
   name: string;
   version: string;
+  type: PackageDependencyType;
+  component: PackageDependencyComponentType;
 };

--- a/packages/cv-wrapper/tsconfig.node.json
+++ b/packages/cv-wrapper/tsconfig.node.json
@@ -1,6 +1,11 @@
 {
   "extends": "@tsconfig/node20/tsconfig.json",
-  "include": ["vite.config.*", "./package.json"],
+  "include": [
+    "vite.config.*",
+    "./package.json",
+    "../cv-content/package.json",
+    "../../package.json"
+  ],
   "compilerOptions": {
     "composite": true,
     "noEmit": true,

--- a/packages/cv-wrapper/tsconfig.node.json
+++ b/packages/cv-wrapper/tsconfig.node.json
@@ -1,6 +1,6 @@
 {
   "extends": "@tsconfig/node20/tsconfig.json",
-  "include": ["vite.config.*"],
+  "include": ["vite.config.*", "./package.json"],
   "compilerOptions": {
     "composite": true,
     "noEmit": true,

--- a/packages/cv-wrapper/vite.config.ts
+++ b/packages/cv-wrapper/vite.config.ts
@@ -6,6 +6,8 @@ import { defineConfig } from 'vite';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath, URL } from 'node:url';
 
+import packageJson from './package.json';
+
 // https://vitejs.dev/config/
 export default defineConfig({
   base: './',
@@ -19,6 +21,17 @@ export default defineConfig({
       ),
     }),
   ],
+  define: {
+    'import.meta.env.PACKAGE_REPOSITORY_URL': JSON.stringify(
+      packageJson.repository.url,
+    ),
+    'import.meta.env.PACKAGE_DEPENDENCIES': JSON.stringify(
+      packageJson.dependencies,
+    ),
+    'import.meta.env.PACKAGE_DEV_DEPENDENCIES': JSON.stringify(
+      packageJson.devDependencies,
+    ),
+  },
   resolve: {
     alias: {
       '@': fileURLToPath(new URL('./src', import.meta.url)),

--- a/packages/cv-wrapper/vite.config.ts
+++ b/packages/cv-wrapper/vite.config.ts
@@ -6,7 +6,9 @@ import { defineConfig } from 'vite';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath, URL } from 'node:url';
 
-import packageJson from './package.json';
+import packageJson from '../../package.json';
+import cvContentPackageJson from '../cv-content/package.json';
+import cvWrapperPackageJson from './package.json';
 
 // https://vitejs.dev/config/
 export default defineConfig({
@@ -25,11 +27,17 @@ export default defineConfig({
     'import.meta.env.PACKAGE_REPOSITORY_URL': JSON.stringify(
       packageJson.repository.url,
     ),
-    'import.meta.env.PACKAGE_DEPENDENCIES': JSON.stringify(
-      packageJson.dependencies,
-    ),
     'import.meta.env.PACKAGE_DEV_DEPENDENCIES': JSON.stringify(
       packageJson.devDependencies,
+    ),
+    'import.meta.env.CV_CONTENT_PACKAGE_DEV_DEPENDENCIES': JSON.stringify(
+      cvContentPackageJson.devDependencies,
+    ),
+    'import.meta.env.CV_WRAPPER_PACKAGE_DEPENDENCIES': JSON.stringify(
+      cvWrapperPackageJson.dependencies,
+    ),
+    'import.meta.env.CV_WRAPPER_PACKAGE_DEV_DEPENDENCIES': JSON.stringify(
+      cvWrapperPackageJson.devDependencies,
     ),
   },
   resolve: {


### PR DESCRIPTION
# Changes
- Updated vite configuration to extract dependency information from different package.json files (due to monorepo)
- Added custom type for dependency, type and affected software component
- Added localizations
- Added helper method to generate list of all dependencies using custom type
- Added update of PrimeVue localizations when changing language
- Added information button to menubar that opens the dialog
- Added CvAppInformationDialogButton component
- Added CvDependencyDataTable component